### PR TITLE
fix: resolve wasm url

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -17,7 +17,7 @@ buf = Buffer.from(src, 'base64')
 `
 
 const browserFilePath = `
-return instantiate(fetch(filepath), imports, true);
+return instantiate(fetch(new URL(filepath, import.meta.url)), imports, true);
 `
 
 const browserDecode = `

--- a/tests/__snapshots__/init/browser.snap
+++ b/tests/__snapshots__/init/browser.snap
@@ -9,7 +9,7 @@ function loadWasmModule(sync, filepath, src, imports) {
 	}
 	let buf = null;
 	if (filepath) {
-		return instantiate(fetch(filepath), imports, true);
+		return instantiate(fetch(new URL(filepath, import.meta.url)), imports, true);
 	}
 	const raw = globalThis.atob(src);
 	const len = raw.length;

--- a/tests/__snapshots__/init/neutral.snap
+++ b/tests/__snapshots__/init/neutral.snap
@@ -14,7 +14,7 @@ function loadWasmModule(sync, filepath, src, imports) {
 		const path = process.getBuiltinModule("path");
 		return readFile(path.resolve(import.meta.dirname, filepath)).then((buffer) => instantiate(buffer, imports));
 	} else if (filepath) {
-		return instantiate(fetch(filepath), imports, true);
+		return instantiate(fetch(new URL(filepath, import.meta.url)), imports, true);
 	}
 	if (isNode) {
 		const { Buffer } = process.getBuiltinModule("buffer");

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -4,6 +4,7 @@ import { Buffer } from 'node:buffer'
 import { readFile } from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
+import { pathToFileURL } from 'node:url'
 import { createContext, SourceTextModule } from 'node:vm'
 import { rolldownBuild, testFixtures } from '@sxzz/test-utils'
 import { describe, expect, test } from 'vitest'
@@ -63,6 +64,7 @@ async function e2e(
   const code = chunks[0].code
   const mod = new SourceTextModule(code, {
     context: createContext({
+      URL,
       atob: platform === 'browser' ? atob : undefined,
       fetch:
         platform === 'browser' && maxFileSize === 0
@@ -90,6 +92,7 @@ async function e2e(
     }),
     initializeImportMeta: (meta) => {
       meta.dirname = process.cwd()
+      meta.url = pathToFileURL(`${process.cwd()}/`).href
     },
   })
   await mod.link((spec) => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/sxzz/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [ ] This PR contains AI-generated code, **but I have carefully reviewed it myself**. Otherwise, my PR may be closed.
  - [ ] I understand that my PR is more likely to be rejected or requested for changes if it contains AI-generated code that I do not fully understand.

### Description
This PR fixes the wasm load logic in the browser environment. With `new URL(filepath, import.meta.url)`, a build tool like Vite can load the wasm file correctly.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
fix: https://github.com/sxzz/rolldown-plugin-wasm/issues/3
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
